### PR TITLE
fix: sync changelog between CHANGELOG.md and MkDocs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,4 @@
 # Changelog
 
-## [Unreleased]
-
-### Added
-- Initial implementation of fastapi-agentrouter
-- Support for Slack, Discord, and webhook integrations
-- FastAPI router builder with platform-specific handlers
-- Comprehensive test suite
-- CI/CD with GitHub Actions
-- Documentation with MkDocs Material
+<!-- Include the main CHANGELOG.md file -->
+--8<-- "CHANGELOG.md"


### PR DESCRIPTION
## Summary
- Eliminate duplicate changelog definitions between CHANGELOG.md and docs/changelog.md
- Use MkDocs snippets extension to include CHANGELOG.md directly in documentation
- Ensure single source of truth for changelog maintained by release-please

## Changes
- Modified `docs/changelog.md` to use MkDocs snippets syntax (`--8<--`) to include CHANGELOG.md
- This ensures the release-please managed CHANGELOG.md is automatically reflected in MkDocs/GitHub Pages

## Test plan
- [x] Verified MkDocs build works with `uv run mkdocs build --strict`
- [x] Confirmed CHANGELOG.md content appears in built documentation
- [x] Tested that release-please workflow remains unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)