### PR TITLE
feat: change MkDocs theme color to match FastAPI green

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,14 +38,14 @@ theme:
     - content.code.annotate
   palette:
     - scheme: default
-      primary: blue
-      accent: blue
+      primary: teal
+      accent: teal
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - scheme: slate
-      primary: blue
-      accent: blue
+      primary: teal
+      accent: teal
       toggle:
         icon: material/brightness-4
         name: Switch to light mode


### PR DESCRIPTION
## Summary
- Changed MkDocs Material theme colors from blue to teal
- Applied color change to both light and dark mode schemes
- Matches the green color scheme used in official FastAPI documentation

## Test plan
- [x] Built documentation locally with `uv run mkdocs build --strict`
- [x] No build errors or warnings
- [ ] Verify color scheme matches FastAPI green in deployed preview

🤖 Generated with [Claude Code](https://claude.ai/code)