### PR TITLE
refactor: improve settings configuration with dependency injection

### DIFF
--- a/src/fastapi_agentrouter/core/settings.py
+++ b/src/fastapi_agentrouter/core/settings.py
@@ -1,5 +1,8 @@
 """Settings management for FastAPI AgentRouter using pydantic-settings."""
 
+from typing import Annotated
+
+from fastapi import Depends
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -18,19 +21,33 @@ class Settings(BaseSettings):
     )
 
     # Platform enable/disable settings
-    disable_slack: bool = Field(
+    enable_slack: bool = Field(
         default=False,
-        description="Disable Slack integration endpoints",
-    )
-    disable_discord: bool = Field(
-        default=False,
-        description="Disable Discord integration endpoints",
-    )
-    disable_webhook: bool = Field(
-        default=False,
-        description="Disable webhook endpoints",
+        description="Enable Slack integration endpoints",
     )
 
 
-# Create a singleton instance
-settings = Settings()
+# Create a singleton instance for environment-based settings
+_env_settings = Settings()
+
+
+def get_settings() -> Settings:
+    """Get the current settings instance.
+    
+    This function can be overridden using FastAPI's dependency_overrides
+    to provide custom settings without environment variables.
+    
+    Example:
+        from fastapi_agentrouter.core.settings import Settings, get_settings
+        
+        custom_settings = Settings(enable_slack=True)
+        app.dependency_overrides[get_settings] = lambda: custom_settings
+    """
+    return _env_settings
+
+
+# Dependency type for settings injection
+SettingsDep = Annotated[Settings, Depends(get_settings)]
+
+# For backward compatibility
+settings = _env_settings

--- a/src/fastapi_agentrouter/integrations/slack/dependencies.py
+++ b/src/fastapi_agentrouter/integrations/slack/dependencies.py
@@ -2,12 +2,12 @@
 
 from fastapi import HTTPException
 
-from ...core.settings import settings
+from ...core.settings import SettingsDep
 
 
-def check_slack_enabled() -> None:
+def check_slack_enabled(settings: SettingsDep) -> None:
     """Check if Slack integration is enabled."""
-    if settings.disable_slack:
+    if not settings.enable_slack:
         raise HTTPException(
             status_code=404,
             detail="Slack integration is not enabled",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from fastapi_agentrouter import get_agent_placeholder, router
+from fastapi_agentrouter.core.settings import Settings, get_settings
 
 
 class MockAgent:
@@ -44,6 +45,8 @@ def test_app(get_agent_factory) -> FastAPI:
     app = FastAPI()
     # Override the placeholder dependency
     app.dependency_overrides[get_agent_placeholder] = get_agent_factory
+    # Enable Slack for testing by default
+    app.dependency_overrides[get_settings] = lambda: Settings(enable_slack=True)
     app.include_router(router)
     return app
 

--- a/tests/integrations/slack/test_slack.py
+++ b/tests/integrations/slack/test_slack.py
@@ -7,12 +7,11 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from fastapi_agentrouter import get_agent_placeholder, router
-from fastapi_agentrouter.core.settings import settings
+from fastapi_agentrouter.core.settings import Settings, get_settings
 
 
-def test_slack_disabled(monkeypatch):
+def test_slack_disabled():
     """Test Slack endpoint when disabled."""
-    monkeypatch.setattr(settings, "disable_slack", True)
 
     def get_agent():
         class Agent:
@@ -21,8 +20,10 @@ def test_slack_disabled(monkeypatch):
 
         return Agent()
 
+    # Create app with disabled Slack
     app = FastAPI()
     app.dependency_overrides[get_agent_placeholder] = get_agent
+    app.dependency_overrides[get_settings] = lambda: Settings(enable_slack=False)
     app.include_router(router)
     client = TestClient(app)
 
@@ -105,6 +106,7 @@ def test_slack_missing_library():
 
     app = FastAPI()
     app.dependency_overrides[get_agent_placeholder] = get_agent
+    app.dependency_overrides[get_settings] = lambda: Settings(enable_slack=True)
     app.include_router(router)
     client = TestClient(app)
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -3,7 +3,7 @@
 import pytest
 from fastapi import HTTPException
 
-from fastapi_agentrouter.core.settings import settings
+from fastapi_agentrouter.core.settings import Settings
 from fastapi_agentrouter.integrations.slack.dependencies import check_slack_enabled
 
 
@@ -19,15 +19,15 @@ def test_agent_protocol():
     assert hasattr(agent, "stream_query")
 
 
-def test_check_slack_enabled(monkeypatch):
+def test_check_slack_enabled():
     """Test check_slack_enabled function."""
-    # Should not raise when not disabled
-    monkeypatch.setattr(settings, "disable_slack", False)
-    check_slack_enabled()
-
-    # Should raise when disabled
-    monkeypatch.setattr(settings, "disable_slack", True)
+    # Should raise when disabled (default)
+    settings = Settings()
     with pytest.raises(HTTPException) as exc_info:
-        check_slack_enabled()
+        check_slack_enabled(settings)
     assert exc_info.value.status_code == 404
     assert "Slack integration is not enabled" in exc_info.value.detail
+
+    # Should not raise when enabled
+    settings = Settings(enable_slack=True)
+    check_slack_enabled(settings)  # Should not raise

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from fastapi_agentrouter import get_agent_placeholder, router
+from fastapi_agentrouter.core.settings import Settings, get_settings
 
 
 def test_router_includes_slack_endpoint(test_client: TestClient):
@@ -53,6 +54,7 @@ def test_complete_integration():
 
     app = FastAPI()
     app.dependency_overrides[get_agent_placeholder] = get_agent
+    app.dependency_overrides[get_settings] = lambda: Settings(enable_slack=True)
     app.include_router(router)
     client = TestClient(app)
 


### PR DESCRIPTION
## Summary
- Removed unused `disable_discord` and `disable_webhook` settings
- Changed `disable_slack` to `enable_slack` with default=False for clearer semantics
- Added dependency injection support for settings configuration without environment variables

## Breaking Changes
⚠️ **BREAKING CHANGE**: Changed `disable_slack` to `enable_slack` (inverted logic)
- Previous: `disable_slack=True` meant Slack was disabled
- New: `enable_slack=False` means Slack is disabled (default)

## New Features
### Dependency Injection for Settings
Settings can now be overridden using FastAPI's dependency injection without environment variables:

```python
from fastapi_agentrouter.core.settings import Settings, get_settings

# Create custom settings
custom_settings = Settings(enable_slack=True)

# Override in your FastAPI app
app.dependency_overrides[get_settings] = lambda: custom_settings
```

This allows for:
- Easier testing with different configurations
- Runtime configuration without environment variables
- Multiple apps with different settings in the same process

## Test Plan
- [x] All existing tests pass
- [x] Settings dependency injection works correctly
- [x] Slack integration respects the new enable_slack setting
- [x] Tests updated to use new dependency injection mechanism

🤖 Generated with [Claude Code](https://claude.ai/code)