### PR TITLE
feat: add auto-approve and auto-merge workflow for chanyou0311 PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,87 @@
+name: Auto Approve and Merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
+  check_suite:
+    types: [completed]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+jobs:
+  auto-approve:
+    name: Auto Approve PR
+    runs-on: ubuntu-latest
+    # PRの作成者がchanyou0311であることを確認
+    if: github.event.pull_request.user.login == 'chanyou0311'
+    steps:
+      - name: Approve PR
+        uses: hmarr/auto-approve-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  auto-merge:
+    name: Auto Merge PR
+    runs-on: ubuntu-latest
+    needs: auto-approve
+    # PRの作成者がchanyou0311かつ、auto-mergeが有効になっていることを確認
+    if: |
+      github.event.pull_request.user.login == 'chanyou0311' &&
+      github.event.pull_request.auto_merge != null
+    steps:
+      - name: Check CI Status
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+            
+            // PRのチェック状態を取得
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number
+            });
+            
+            // マージ可能な状態かチェック
+            if (pr.mergeable_state !== 'clean') {
+              core.info(`PR is not in a clean mergeable state: ${pr.mergeable_state}`);
+              return;
+            }
+            
+            // すべてのステータスチェックが成功しているか確認
+            const { data: checkRuns } = await github.rest.checks.listForRef({
+              owner,
+              repo,
+              ref: pr.head.sha
+            });
+            
+            const allChecksPassed = checkRuns.check_runs.every(
+              check => check.status === 'completed' && 
+                      (check.conclusion === 'success' || check.conclusion === 'skipped')
+            );
+            
+            if (!allChecksPassed) {
+              core.info('Not all checks have passed yet');
+              return;
+            }
+            
+            // 自動マージを実行
+            try {
+              await github.rest.pulls.merge({
+                owner,
+                repo,
+                pull_number,
+                merge_method: 'squash'
+              });
+              core.info('Successfully merged PR');
+            } catch (error) {
+              core.warning(`Failed to merge PR: ${error.message}`);
+            }


### PR DESCRIPTION
## Summary
- chanyou0311が作成したPRを自動承認・自動マージするGitHub Actionsワークフローを追加
- `hmarr/auto-approve-action`を使用してPRを自動承認
- すべてのCIチェックがパスした後、自動マージを実行

## 実装内容
### 自動承認機能
- PR作成者が`chanyou0311`の場合のみ、`hmarr/auto-approve-action`を使用して自動承認
- `pull_request_target`イベントを使用してセキュアに実行

### 自動マージ機能
- 以下の条件をすべて満たす場合にのみ自動マージ:
  1. PR作成者が`chanyou0311`である
  2. PRでauto-mergeが有効になっている
  3. すべてのCIチェックがパスしている
  4. PRがマージ可能な状態である

## 必要なリポジトリ設定

このワークフローを完全に機能させるために、以下の設定が必要です：

### ✅ 既に有効な設定
- **Allow auto-merge**: 有効（確認済み）

### ⚠️ 推奨される追加設定

#### Branch Protection Rules（mainブランチ）
現在、mainブランチにprotection ruleが設定されていないため、以下の設定を推奨します：

1. **Settings > Branches > Add rule** から新しいルールを作成
2. Branch name pattern: `main`
3. 以下のオプションを有効化：
   - ✅ **Require a pull request before merging**
     - ✅ **Required approvals**: 1
     - ✅ **Dismiss stale pull request approvals when new commits are pushed**
   - ✅ **Require status checks to pass before merging**
     - 必要なCIチェック（CI workflow）を選択
   - ✅ **Require branches to be up to date before merging**

#### GitHub Actionsの権限設定
1. **Settings > Actions > General**
2. **Workflow permissions**:
   - ✅ **Allow GitHub Actions to create and approve pull requests** を有効化
     （これによりGitHub ActionsがPRを承認できるようになります）

## 使用方法

1. PRを作成（作成者: chanyou0311）
2. PRで"Enable auto-merge"ボタンをクリックして自動マージを有効化
3. ワークフローが自動的にPRを承認
4. すべてのCIチェックがパスした後、自動的にマージされる

## テスト計画
- [x] ワークフローファイルの作成
- [ ] このPRでワークフローの動作を確認
- [ ] Branch protection rulesを設定後、実際の動作を確認

## 注意事項
- `pull_request_target`を使用しているため、フォークからのPRでも動作しますが、作成者チェックにより`chanyou0311`以外は承認されません
- セキュリティを考慮し、GitHub提供の`GITHUB_TOKEN`を使用

🤖 Generated with [Claude Code](https://claude.ai/code)