### PR TITLE
fix: enable CI workflows for release-please PRs

### DIFF
--- a/.github/RELEASE_PLEASE_CI_SETUP.md
+++ b/.github/RELEASE_PLEASE_CI_SETUP.md
@@ -1,0 +1,49 @@
+# Release Please CI Setup
+
+This document explains how to configure release-please to trigger CI workflows on its PRs.
+
+## Background
+
+By default, when release-please creates PRs using the default `GITHUB_TOKEN`, GitHub doesn't trigger workflows on those PRs for security reasons. This causes required CI checks to remain in "Expected" state, blocking the PRs.
+
+## Solution
+
+We've implemented a two-part solution:
+
+### 1. CI Workflow Updates
+
+The CI workflow (`ci.yml`) has been updated to:
+- Also trigger on `pull_request_target` events
+- Include security checks to only run on legitimate release-please PRs
+- Properly checkout the PR's code when running in `pull_request_target` mode
+
+### 2. Personal Access Token (Optional but Recommended)
+
+For the best experience, configure a Personal Access Token:
+
+1. Create a new Personal Access Token (PAT) with `repo` and `workflow` permissions:
+   - Go to GitHub Settings → Developer settings → Personal access tokens
+   - Create a token with `repo` and `workflow` scopes
+
+2. Add the token as a repository secret:
+   - Go to repository Settings → Secrets and variables → Actions
+   - Create a new secret named `RELEASE_PLEASE_TOKEN`
+   - Paste your PAT as the value
+
+3. The `release-please.yml` workflow will automatically use this token if available
+
+## How It Works
+
+- **With PAT**: Release-please creates PRs using the PAT, which triggers CI workflows normally
+- **Without PAT (Fallback)**: The CI workflow uses `pull_request_target` to run on release-please PRs created by github-actions[bot]
+
+## Security
+
+The `pull_request_target` trigger includes security checks:
+- Only runs for PRs from `github-actions[bot]` or `release-please[bot]`
+- Only runs for PRs with branch names matching the release-please pattern
+- Checks out the PR's head SHA to test the actual PR code
+
+## Verification
+
+After setup, release-please PRs should show all required CI checks running instead of being stuck in "Expected" state.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,46 @@ on:
   pull_request:
     branches:
       - main
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Security check for pull_request_target
+  # Only run on pull_request_target for release-please PRs from github-actions bot
+  security-check:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - id: check
+        run: |
+          if [[ "${{ github.actor }}" == "github-actions[bot]" && "${{ github.event.pull_request.head.ref }}" =~ ^release-please--branches--main ]] ||
+             [[ "${{ github.actor }}" == "release-please[bot]" ]]; then
+            echo "should-run=true" >> $GITHUB_OUTPUT
+            echo "✅ Running CI for release-please PR"
+          else
+            echo "should-run=false" >> $GITHUB_OUTPUT
+            echo "⏭️ Skipping CI for non-release-please pull_request_target"
+          fi
+
   test:
+    # Run on normal pull_request events OR approved pull_request_target events
+    needs: [security-check]
+    if: |
+      !cancelled() && (
+        github.event_name == 'pull_request' ||
+        (github.event_name == 'pull_request_target' && needs.security-check.outputs.should-run == 'true')
+      )
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -18,6 +51,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          # For pull_request_target, checkout the PR's head ref
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6
@@ -37,9 +73,18 @@ jobs:
         run: uv run pytest --cov=src --cov-report=xml
 
   docs:
+    needs: [security-check]
+    if: |
+      !cancelled() && (
+        github.event_name == 'pull_request' ||
+        (github.event_name == 'pull_request_target' && needs.security-check.outputs.should-run == 'true')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          # For pull_request_target, checkout the PR's head ref
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,6 +23,7 @@ jobs:
         uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4
         with:
           release-type: python
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
   publish-pypi:
     needs: release-please


### PR DESCRIPTION
## Summary
- Updates CI workflow to support `pull_request_target` for release-please PRs
- Adds security checks to ensure only legitimate release-please PRs trigger CI
- Configures release-please to optionally use a Personal Access Token (PAT)

## Problem
Currently, when release-please creates PRs (like #41), the required CI workflows don't trigger and remain in "Expected" state. This is because GitHub doesn't trigger workflows on PRs created by the default GITHUB_TOKEN for security reasons.

## Solution
This PR implements a two-part solution:

### 1. CI Workflow Updates
- Added `pull_request_target` trigger to CI workflow
- Implemented security checks to only run on release-please PRs
- Properly checkout PR code when running in `pull_request_target` mode

### 2. PAT Support (Optional)
- Updated release-please workflow to use `RELEASE_PLEASE_TOKEN` if available
- Falls back to `GITHUB_TOKEN` if PAT is not configured
- Added documentation explaining the setup

## Setup Instructions
After merging this PR:
1. (Optional but recommended) Create a PAT with `repo` and `workflow` permissions
2. Add it as a repository secret named `RELEASE_PLEASE_TOKEN`
3. Future release-please PRs will have CI workflows running properly

## Security Considerations
The `pull_request_target` implementation includes:
- Strict actor checks (only `github-actions[bot]` or `release-please[bot]`)
- Branch name pattern validation
- Proper checkout of PR head SHA to test actual PR code

## Test Plan
- [x] Verify CI workflow syntax is valid
- [ ] After merge, next release-please PR should have CI workflows running
- [ ] Ensure normal PRs still trigger CI as expected
- [ ] Security checks properly filter non-release-please PRs

Fixes the issue where release-please PRs get stuck with CI in "Expected" state.

🤖 Generated with [Claude Code](https://claude.ai/code)