### PR TITLE
fix: enable CI workflow for release-please PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,6 +23,7 @@ jobs:
         uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4
         with:
           release-type: python
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
   publish-pypi:
     needs: release-please


### PR DESCRIPTION
## Summary
- Add explicit PR event types to CI workflow to ensure it runs for bot-created PRs
- Configure release-please action with token support for workflow triggering
- Fix the issue where CI checks remain "Expected" on release-please PRs (as seen in #41)

## Problem
Release-please creates PRs using the default `GITHUB_TOKEN`, which has limitations on triggering other workflows. This causes required CI checks to remain in "Expected" state indefinitely, blocking the PR merge.

## Solution
1. **CI Workflow**: Added explicit PR event types (`opened`, `synchronize`, `reopened`, `ready_for_review`) to ensure the workflow triggers for bot-created PRs
2. **Release-Please**: Added token configuration that allows using a custom PAT (`RELEASE_PLEASE_TOKEN`) if available, falling back to `GITHUB_TOKEN`

## Test plan
- [ ] CI workflow runs successfully on this PR
- [ ] Verify that future release-please PRs will trigger CI checks
- [ ] Confirm no impact on regular PR workflows

## Related Issues
- Fixes the CI blocking issue seen in PR #41

🤖 Generated with [Claude Code](https://claude.ai/code)