### PR TITLE
feat: improve type hints for AgentProtocol and add examples gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+examples/*.env
 .claude/settings.local.json
 
 # Byte-compiled / optimized / DLL files

--- a/src/fastapi_agentrouter/core/dependencies.py
+++ b/src/fastapi_agentrouter/core/dependencies.py
@@ -1,5 +1,6 @@
 """Core dependencies for FastAPI AgentRouter."""
 
+from collections.abc import Generator
 from typing import Annotated, Any, Protocol
 
 from fastapi import Depends, HTTPException
@@ -15,7 +16,7 @@ class AgentProtocol(Protocol):
         user_id: str | None = None,
         session_id: str | None = None,
         **kwargs: Any,
-    ) -> Any:
+    ) -> Generator[dict[str, Any], Any, None]:
         """Stream responses from the agent."""
         ...
 


### PR DESCRIPTION
## Summary
- Update `AgentProtocol.stream_query` return type to `Generator[dict[str, Any], Any, None]` for better type safety and clarity
- Add `examples/*.env` to `.gitignore` to prevent example environment files from being tracked

## Changes
- **Type Improvements**: Enhanced the `stream_query` method signature in `AgentProtocol` to use proper Generator typing with specific dict return type
- **DevEx**: Added `examples/*.env` pattern to gitignore for better example environment management

## Test plan
- [x] Verify type checking passes with `mypy src`
- [x] Ensure existing functionality remains unchanged
- [x] Confirm environment files are properly ignored

🤖 Generated with [Claude Code](https://claude.ai/code)