### PR TITLE
fix: remove debug say() call in Slack app_mention handler

### DIFF
--- a/src/fastapi_agentrouter/integrations/slack/dependencies.py
+++ b/src/fastapi_agentrouter/integrations/slack/dependencies.py
@@ -43,7 +43,6 @@ def get_app_mention(agent: AgentDep) -> Callable[[dict, Any, dict], None]:
         user: str = event.get("user", "u_123")
         text: str = event.get("text", "")
         logger.info(f"App mentioned by user {user}: {text}")
-        say(text)
 
         full_response_text = ""
         for event_data in agent.stream_query(


### PR DESCRIPTION
## Summary
- Removed the debug `say(text)` call that was echoing user messages back to Slack
- This eliminates unnecessary noise in production use
- The handler now only sends the actual agent response

## Changes
- Removed line 46: `say(text)` from `src/fastapi_agentrouter/integrations/slack/dependencies.py`
- Kept the actual response `say(full_response_text)` on line 60

## Test plan
- [x] All existing tests pass (`uv run pytest`)
- [x] Pre-commit hooks pass
- [x] Slack app_mention handler still sends agent responses correctly