### PR TITLE
feat: add Slack thread support with session management

### DIFF
--- a/src/fastapi_agentrouter/integrations/slack/dependencies.py
+++ b/src/fastapi_agentrouter/integrations/slack/dependencies.py
@@ -42,11 +42,113 @@ def get_app_mention(agent: AgentDep) -> Callable[[dict, Any, dict], None]:
         """Handle app mention events with agent."""
         user: str = event.get("user", "u_123")
         text: str = event.get("text", "")
-        logger.info(f"App mentioned by user {user}: {text}")
+        channel: str = event.get("channel", "")
+        thread_ts: str = event.get("thread_ts", event.get("ts", ""))
+
+        logger.info(f"App mentioned by user {user} in channel {channel}: {text}")
+
+        # Use thread_ts as session_id for context continuity
+        # Use the first message timestamp as user_id to identify the conversation
+        user_id = thread_ts
+        session_id = f"{channel}_{thread_ts}"
+
+        full_response_text = ""
+        try:
+            for event_data in agent.stream_query(
+                user_id=user_id,
+                session_id=session_id,
+                message=text,
+            ):
+                if (
+                    "content" in event_data
+                    and "parts" in event_data["content"]
+                    and "text" in event_data["content"]["parts"][0]
+                ):
+                    full_response_text += event_data["content"]["parts"][0]["text"]
+                logger.debug(f"Received event_data: {event_data}")
+        except Exception as e:
+            logger.error(f"Error processing agent response: {e}")
+            say(text=f"Sorry, I encountered an error: {e!s}", thread_ts=thread_ts)
+            return
+
+        # Reply in thread only if there's content
+        if full_response_text:
+            logger.info(f"Sending response: {full_response_text[:100]}...")
+            say(text=full_response_text, thread_ts=thread_ts)
+        else:
+            logger.warning("Agent returned empty response")
+            say(
+                text="I received your message but couldn't generate a response.",
+                thread_ts=thread_ts,
+            )
+
+    return app_mention
+
+
+def get_message(agent: AgentDep) -> Callable[[dict, Any, dict, Any], None]:
+    """Get message event handler for thread messages."""
+
+    def message(event: dict, say: Any, body: dict, client: Any) -> None:
+        """Handle message events in threads where bot was mentioned."""
+        # Skip if this is a bot message
+        if event.get("bot_id") or event.get("subtype"):
+            return
+
+        thread_ts = event.get("thread_ts")
+        if not thread_ts:
+            # Not a thread message
+            return
+
+        channel = event.get("channel", "")
+        user = event.get("user", "u_123")
+        text = event.get("text", "")
+
+        # Check if this thread was initiated by a bot mention
+        thread_key = f"{channel}_{thread_ts}"
+
+        # Get thread history to check if bot was mentioned in the thread
+        try:
+            result = client.conversations_replies(
+                channel=channel, ts=thread_ts, limit=100
+            )
+            messages = result.get("messages", [])
+
+            # Check if bot was mentioned in any message in the thread
+            bot_mentioned_in_thread = False
+            bot_user_id = client.auth_test()["user_id"]
+
+            for msg in messages:
+                msg_text = msg.get("text", "")
+                if f"<@{bot_user_id}>" in msg_text:
+                    bot_mentioned_in_thread = True
+                    break
+
+            if not bot_mentioned_in_thread:
+                # Bot was never mentioned in this thread, ignore
+                return
+
+        except Exception as e:
+            logger.error(f"Error checking thread history: {e}")
+            return
+
+        # Check if message contains (aside) and bot is not mentioned
+        bot_mentioned_in_message = f"<@{bot_user_id}>" in text
+        if "(aside)" in text and not bot_mentioned_in_message:
+            logger.info(f"Ignoring message with (aside) in thread {thread_key}")
+            return
+
+        logger.info(
+            f"Processing message in thread {thread_key} from user {user}: {text}"
+        )
+
+        # Use thread_ts as both user_id and part of session_id for context continuity
+        user_id = thread_ts
+        session_id = thread_key
 
         full_response_text = ""
         for event_data in agent.stream_query(
-            user_id="u_123",
+            user_id=user_id,
+            session_id=session_id,
             message=text,
         ):
             if (
@@ -56,15 +158,18 @@ def get_app_mention(agent: AgentDep) -> Callable[[dict, Any, dict], None]:
             ):
                 full_response_text += event_data["content"]["parts"][0]["text"]
 
-        say(full_response_text)
+        # Reply in thread
+        if full_response_text:
+            say(text=full_response_text, thread_ts=thread_ts)
 
-    return app_mention
+    return message
 
 
 def get_slack_app(
     settings: SettingsDep,
     ack: Annotated[Callable[[dict, Any], None], Depends(get_ack)],
     app_mention: Annotated[Callable[[dict, Any, dict], None], Depends(get_app_mention)],
+    message: Annotated[Callable[[dict, Any, dict], None], Depends(get_message)],
 ) -> "SlackApp":
     """Create and configure Slack App with agent dependency."""
     try:
@@ -95,6 +200,7 @@ def get_slack_app(
 
     # Register event handlers with lazy listeners
     slack_app.event("app_mention")(ack=ack, lazy=[app_mention])
+    slack_app.event("message")(ack=ack, lazy=[message])
 
     return slack_app
 

--- a/tests/integrations/slack/test_slack.py
+++ b/tests/integrations/slack/test_slack.py
@@ -156,3 +156,226 @@ def test_slack_missing_library():
         )
         assert response.status_code == 500
         assert "slack-bolt is required" in response.json()["detail"]
+
+
+def test_slack_thread_reply():
+    """Test that bot replies in thread when mentioned."""
+
+    def get_mock_agent():
+        class Agent:
+            def stream_query(self, **kwargs):
+                # Check that session_id is properly set for thread
+                assert "session_id" in kwargs
+                assert kwargs["session_id"].startswith("C123_")
+                yield {"content": {"parts": [{"text": "Thread reply"}]}}
+
+        return Agent()
+
+    app = FastAPI()
+    app.dependency_overrides[get_agent] = get_mock_agent
+    app.dependency_overrides[get_settings] = lambda: Settings(
+        slack=SlackSettings(bot_token="test-token", signing_secret="test-secret")
+    )
+    app.include_router(router)
+
+    with (
+        patch("slack_bolt.App") as mock_app_class,
+        patch("slack_bolt.adapter.fastapi.SlackRequestHandler"),
+    ):
+        # Create mock say function to verify thread reply
+        say_called_with = {}
+
+        def mock_say(**kwargs):
+            say_called_with.update(kwargs)
+
+        # Mock the Slack app
+        mock_app = Mock()
+        mock_app.event = Mock(side_effect=lambda event_type: lambda **kwargs: None)
+        mock_app_class.return_value = mock_app
+
+        # Import after patching to get our dependencies
+        from fastapi_agentrouter.integrations.slack.dependencies import get_app_mention
+
+        # Get the handler and test it
+        agent = get_mock_agent()
+        app_mention_handler = get_app_mention(agent)
+
+        # Test app mention in thread
+        event = {
+            "type": "app_mention",
+            "text": "<@U123> help me",
+            "user": "U456",
+            "channel": "C123",
+            "ts": "1234567890.123456",
+            "thread_ts": "1234567890.123456",  # Same as ts for thread start
+        }
+
+        app_mention_handler(event, mock_say, {})
+
+        # Verify say was called with thread_ts
+        assert "thread_ts" in say_called_with
+        assert say_called_with["thread_ts"] == "1234567890.123456"
+        assert say_called_with["text"] == "Thread reply"
+
+
+def test_slack_message_in_thread():
+    """Test that bot responds to messages in threads where it was mentioned."""
+
+    def get_mock_agent():
+        class Agent:
+            def stream_query(self, **kwargs):
+                # Verify session continuity
+                assert kwargs["session_id"] == "C123_1234567890.000000"
+                assert kwargs["user_id"] == "1234567890.000000"
+                yield {"content": {"parts": [{"text": "Continued conversation"}]}}
+
+        return Agent()
+
+    app = FastAPI()
+    app.dependency_overrides[get_agent] = get_mock_agent
+    app.dependency_overrides[get_settings] = lambda: Settings(
+        slack=SlackSettings(bot_token="test-token", signing_secret="test-secret")
+    )
+    app.include_router(router)
+
+    with patch("slack_bolt.App"):
+        # Create mock client and say
+        mock_client = Mock()
+        mock_client.auth_test = Mock(return_value={"user_id": "U_BOT"})
+        mock_client.conversations_replies = Mock(
+            return_value={
+                "messages": [
+                    {"text": "<@U_BOT> initial mention", "ts": "1234567890.000000"},
+                    {"text": "follow up message", "ts": "1234567890.000001"},
+                ]
+            }
+        )
+
+        say_called_with = {}
+
+        def mock_say(**kwargs):
+            say_called_with.update(kwargs)
+
+        # Import and get handler
+        from fastapi_agentrouter.integrations.slack.dependencies import get_message
+
+        agent = get_mock_agent()
+        message_handler = get_message(agent)
+
+        # Test message in thread (not a mention)
+        event = {
+            "type": "message",
+            "text": "follow up question",
+            "user": "U456",
+            "channel": "C123",
+            "ts": "1234567890.000002",
+            "thread_ts": "1234567890.000000",  # Thread started earlier
+        }
+
+        message_handler(event, mock_say, {}, mock_client)
+
+        # Verify response was sent to thread
+        assert say_called_with["thread_ts"] == "1234567890.000000"
+        assert say_called_with["text"] == "Continued conversation"
+
+
+def test_slack_message_with_aside_ignored():
+    """Test that messages with (aside) are ignored unless bot is mentioned."""
+
+    def get_mock_agent():
+        class Agent:
+            def stream_query(self, **kwargs):
+                # Should not be called for (aside) messages
+                raise AssertionError("Agent should not be called for (aside) messages")
+
+        return Agent()
+
+    with patch("slack_bolt.App"):
+        # Create mock client
+        mock_client = Mock()
+        mock_client.auth_test = Mock(return_value={"user_id": "U_BOT"})
+        mock_client.conversations_replies = Mock(
+            return_value={
+                "messages": [
+                    {"text": "<@U_BOT> start", "ts": "1234567890.000000"},
+                ]
+            }
+        )
+
+        say_called = False
+
+        def mock_say(**kwargs):
+            nonlocal say_called
+            say_called = True
+
+        from fastapi_agentrouter.integrations.slack.dependencies import get_message
+
+        agent = get_mock_agent()
+        message_handler = get_message(agent)
+
+        # Test message with (aside) - should be ignored
+        event = {
+            "type": "message",
+            "text": "(aside) this should be ignored",
+            "user": "U456",
+            "channel": "C123",
+            "ts": "1234567890.000001",
+            "thread_ts": "1234567890.000000",
+        }
+
+        message_handler(event, mock_say, {}, mock_client)
+
+        # Verify say was not called
+        assert not say_called
+
+
+def test_slack_mention_with_aside_processed():
+    """Test that bot mention with (aside) is still processed."""
+
+    def get_mock_agent():
+        class Agent:
+            def stream_query(self, **kwargs):
+                # Should be called even with (aside) when mentioned
+                yield {"content": {"parts": [{"text": "Processed with aside"}]}}
+
+        return Agent()
+
+    with patch("slack_bolt.App"):
+        # Create mock client
+        mock_client = Mock()
+        mock_client.auth_test = Mock(return_value={"user_id": "U_BOT"})
+        mock_client.conversations_replies = Mock(
+            return_value={
+                "messages": [
+                    {
+                        "text": "<@U_BOT> (aside) but still process",
+                        "ts": "1234567890.000000",
+                    },
+                ]
+            }
+        )
+
+        say_called_with = {}
+
+        def mock_say(**kwargs):
+            say_called_with.update(kwargs)
+
+        from fastapi_agentrouter.integrations.slack.dependencies import get_message
+
+        agent = get_mock_agent()
+        message_handler = get_message(agent)
+
+        # Test message with (aside) but bot is mentioned
+        event = {
+            "type": "message",
+            "text": "<@U_BOT> (aside) but process this",
+            "user": "U456",
+            "channel": "C123",
+            "ts": "1234567890.000001",
+            "thread_ts": "1234567890.000000",
+        }
+
+        message_handler(event, mock_say, {}, mock_client)
+
+        # Verify say was called despite (aside)
+        assert say_called_with["text"] == "Processed with aside"


### PR DESCRIPTION
## Summary
- Add thread-based conversation support for Slack integration
- Implement session management per thread for context continuity  
- Handle messages in threads without explicit bot mentions

## Changes
This PR enhances the Slack integration to support threaded conversations with proper session management:

### Thread Support
- Bot now replies in threads when mentioned (creates new thread if needed)
- Maintains conversation context within each thread

### Session Management  
- Each thread has its own session using `channel_thread_ts` as session ID
- Thread timestamp is used as user ID to maintain conversation identity
- Enables context-aware multi-turn conversations within threads

### Smart Message Handling
- Responds to all messages in threads where bot was previously mentioned
- No explicit mention required for follow-up messages in active threads
- Supports `(aside)` notation - messages with `(aside)` are ignored unless bot is explicitly mentioned
- No caching - fetches thread history from Slack API on each message

## Test Plan
✅ All existing tests pass
✅ Added comprehensive test coverage for new features:
- Thread reply functionality
- Session continuity in threads
- Message handling without mentions
- `(aside)` message filtering

✅ Code quality checks:
- Linting with Ruff
- Type checking with MyPy
- Pre-commit hooks

🤖 Generated with [Claude Code](https://claude.ai/code)