### PR TITLE
feat: enable Slack bot to reply in threads

### DIFF
--- a/src/fastapi_agentrouter/integrations/slack/dependencies.py
+++ b/src/fastapi_agentrouter/integrations/slack/dependencies.py
@@ -42,7 +42,10 @@ def get_app_mention(agent: AgentDep) -> Callable[[dict, Any, dict], None]:
         """Handle app mention events with agent."""
         user: str = event.get("user", "u_123")
         text: str = event.get("text", "")
-        logger.info(f"App mentioned by user {user}: {text}")
+        channel: str = event.get("channel", "")
+        # Get thread_ts from event (if in thread) or use the event's ts
+        thread_ts: str = event.get("thread_ts") or event.get("ts", "")
+        logger.info(f"App mentioned by user {user} in channel {channel}: {text}")
 
         # Create a session for this conversation
         session = agent.create_session(user_id=user)
@@ -62,15 +65,88 @@ def get_app_mention(agent: AgentDep) -> Callable[[dict, Any, dict], None]:
             ):
                 full_response_text += event_data["content"]["parts"][0]["text"]
 
-        say(full_response_text)
+        # Reply in thread
+        say(text=full_response_text, channel=channel, thread_ts=thread_ts)
 
     return app_mention
+
+
+def get_message(agent: AgentDep) -> Callable[[dict, Any, Any, dict], None]:
+    """Get message event handler for thread replies."""
+
+    def message(event: dict, say: Any, client: Any, body: dict) -> None:
+        """Handle message events in threads where bot was previously mentioned."""
+        # Only process messages in threads
+        if "thread_ts" not in event:
+            return
+
+        # Skip if this is a bot message
+        if event.get("bot_id") or event.get("subtype") == "bot_message":
+            return
+
+        user: str = event.get("user", "u_123")
+        text: str = event.get("text", "")
+        channel: str = event.get("channel", "")
+        thread_ts: str = event.get("thread_ts", "")
+
+        # Get bot user ID from the auth info
+        bot_user_id = body.get("authorizations", [{}])[0].get("user_id", "")
+
+        # Skip if the message mentions the bot (app_mention will handle it)
+        if bot_user_id and f"<@{bot_user_id}>" in text:
+            return
+
+        # Check if the bot has participated in this thread
+        # Get thread replies to see if bot has responded before
+        result = client.conversations_replies(
+            channel=channel,
+            ts=thread_ts,
+            limit=100,  # Get recent messages in thread
+        )
+
+        # Check if bot has sent any messages in this thread
+        bot_has_responded = False
+        for message in result.get("messages", []):
+            if message.get("user") == bot_user_id:
+                bot_has_responded = True
+                break
+
+        # Only respond if bot has previously participated in the thread
+        if not bot_has_responded:
+            logger.debug(f"Bot has not participated in thread {thread_ts}, skipping")
+            return
+
+        logger.info(f"Message in thread from user {user} in channel {channel}: {text}")
+
+        # Create a session for this conversation
+        session = agent.create_session(user_id=user)
+        session_id = session.get("id")
+        logger.info(f"Created session {session_id} for user {user}")
+
+        full_response_text = ""
+        for event_data in agent.stream_query(
+            user_id=user,
+            session_id=session_id,
+            message=text,
+        ):
+            if (
+                "content" in event_data
+                and "parts" in event_data["content"]
+                and "text" in event_data["content"]["parts"][0]
+            ):
+                full_response_text += event_data["content"]["parts"][0]["text"]
+
+        # Reply in the same thread
+        say(text=full_response_text, channel=channel, thread_ts=thread_ts)
+
+    return message
 
 
 def get_slack_app(
     settings: SettingsDep,
     ack: Annotated[Callable[[dict, Any], None], Depends(get_ack)],
     app_mention: Annotated[Callable[[dict, Any, dict], None], Depends(get_app_mention)],
+    message: Annotated[Callable[[dict, Any, Any, dict], None], Depends(get_message)],
 ) -> "SlackApp":
     """Create and configure Slack App with agent dependency."""
     try:
@@ -101,6 +177,7 @@ def get_slack_app(
 
     # Register event handlers with lazy listeners
     slack_app.event("app_mention")(ack=ack, lazy=[app_mention])
+    slack_app.event("message")(ack=ack, lazy=[message])
 
     return slack_app
 


### PR DESCRIPTION
## Summary
- Modified Slack integration to send bot responses as thread replies instead of new messages
- Added support for continuing conversations in threads without requiring mentions
- Improved conversation organization in Slack channels

## Changes
1. **Thread Reply for Mentions**: When the bot is mentioned, it now replies in a thread instead of sending a new message
   - If the mention is already in a thread, it continues that thread
   - If the mention is in the channel, it starts a new thread

2. **Thread Continuation**: When a message is posted in a thread where the bot has previously responded, the bot will reply even without being mentioned
   - Checks thread history to verify bot participation
   - Prevents duplicate handling when bot is explicitly mentioned

## Test plan
- [x] All existing tests pass
- [x] Linting and formatting checks pass
- [x] Type checking passes
- [ ] Manual testing in Slack workspace:
  - [ ] Mention bot in channel - verify thread is created
  - [ ] Reply in thread without mention - verify bot responds
  - [ ] Mention bot in existing thread - verify proper handling

🤖 Generated with [Claude Code](https://claude.ai/code)