### PR TITLE
ci: add Docker Hub publishing to release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -82,3 +82,44 @@ jobs:
 
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+
+  publish-docker:
+    needs: release-please
+    if: needs.release-please.outputs.release_created
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7 # v5
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/fastapi-agentrouter
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4 # v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Add automatic Docker image publishing to Docker Hub when releases are created
- Integrate with existing Release Please workflow for seamless deployment

## Changes
- Added `publish-docker` job to `.github/workflows/release-please.yml`
- Configured multi-platform builds (linux/amd64, linux/arm64)
- Set up automatic semantic versioning tags (latest, major, major.minor, full version)
- Enabled GitHub Actions cache for faster builds

## Setup Required
Before merging, please ensure the following GitHub Secrets are configured:
1. `DOCKERHUB_USERNAME` - Your Docker Hub username
2. `DOCKERHUB_TOKEN` - Docker Hub access token (create at https://hub.docker.com/settings/security)

## How it Works
When Release Please creates a new release (e.g., `v1.2.3`), the workflow will:
1. Build Docker images for both amd64 and arm64 architectures
2. Push to Docker Hub with the following tags:
   - `yourname/fastapi-agentrouter:latest`
   - `yourname/fastapi-agentrouter:1`
   - `yourname/fastapi-agentrouter:1.2`
   - `yourname/fastapi-agentrouter:1.2.3`

## Testing
The workflow will only trigger on actual releases. To test:
1. Ensure secrets are configured
2. Wait for the next Release Please PR to be merged
3. Verify images appear on Docker Hub

🤖 Generated with [Claude Code](https://claude.ai/code)