### PR TITLE
fix: handle empty response in Slack integration to prevent no_text error

### DIFF
--- a/src/fastapi_agentrouter/integrations/slack/dependencies.py
+++ b/src/fastapi_agentrouter/integrations/slack/dependencies.py
@@ -79,6 +79,13 @@ def get_app_mention(agent: AgentDep) -> Callable[[dict, Any, dict], None]:
             ):
                 full_response_text += event_data["content"]["parts"][0]["text"]
 
+        # Check if response is empty or whitespace-only
+        if not full_response_text.strip():
+            logger.warning(
+                f"Agent returned empty response for thread {thread_id}, using fallback"
+            )
+            full_response_text = "申し訳ございません。応答の生成に失敗しました。"
+
         # Reply in thread
         say(text=full_response_text, channel=channel, thread_ts=thread_ts)
 
@@ -161,6 +168,13 @@ def get_message(agent: AgentDep) -> Callable[[dict, Any, Any, dict], None]:
                 and "text" in event_data["content"]["parts"][0]
             ):
                 full_response_text += event_data["content"]["parts"][0]["text"]
+
+        # Check if response is empty or whitespace-only
+        if not full_response_text.strip():
+            logger.warning(
+                f"Agent returned empty response for thread {thread_id}, using fallback"
+            )
+            full_response_text = "申し訳ございません。応答の生成に失敗しました。"
 
         # Reply in the same thread
         say(text=full_response_text, channel=channel, thread_ts=thread_ts)


### PR DESCRIPTION
## Summary
- Fixes empty response handling in Slack integration to prevent `no_text` error from Slack API
- Adds validation for empty and whitespace-only responses with Japanese fallback message
- Includes comprehensive test coverage for edge cases

## Changes Made
- Updated `get_app_mention` and `get_message` handlers in `src/fastapi_agentrouter/integrations/slack/dependencies.py`
- Added empty response validation with fallback message: "申し訳ございません。応答の生成に失敗しました。"
- Added warning logs when empty responses are detected
- Added 4 new tests covering empty and whitespace-only response scenarios

## Test Plan
- [x] All existing tests pass (19/19)
- [x] New tests verify empty response handling for both app_mention and message events
- [x] New tests verify whitespace-only response handling
- [x] Code passes linting and formatting checks
- [x] Pre-commit hooks pass

## Technical Details
When an agent returns an empty string or whitespace-only content, the Slack API would reject the message with a `no_text` error. This fix detects such cases using `full_response_text.strip()` and substitutes a polite fallback message in Japanese.

Fixes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)